### PR TITLE
chatspaceのグループ管理機能の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,3 +6,4 @@
 @import "module/flash";
 @import "module/messages";
 @import "module/user";
+@import "module/group";

--- a/app/assets/stylesheets/module/_group.scss
+++ b/app/assets/stylesheets/module/_group.scss
@@ -1,0 +1,107 @@
+h1 {
+  letter-spacing: 2px;
+  font-size: 24px;
+  font-weight: bold;
+  text-align: center;
+}
+h2 {
+  margin-bottom: 10px;
+  color: #f05050;
+  font-size: 14px;
+}
+
+ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+li {
+  margin: 0;
+  padding: 0;
+  font-size: 13px;
+}
+
+
+
+.chat-group-form {
+  width: 980px;
+  margin: 60px auto;
+  padding: 40px;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  box-sizing: border-box;
+  &__errors {
+    margin: 30px 0;
+    padding: 20px 40px;
+    border: 1px solid #ddd;
+    border-radius: 2px;
+    text-align: center;
+  }
+  &__label {
+    display: block;
+    line-height: 50px;
+    font-weight: bold;
+    text-align: right;
+  }
+  &__input {
+    float: left;
+    width: 100%;
+    line-height: 30px;
+    padding: 10px 15px;
+    box-sizing: border-box;
+  }
+  &__action-btn {
+    display: inline-block;
+    padding: 12px 20px;
+    color: #fff;
+    background-color: #38aef0;
+    border: 0;
+  }
+  &__field {
+    margin-top: 30px;
+    &:after {
+      content: "";
+      clear: both;
+      display: block;
+    }
+    &--left {
+      float: left;
+      width: 30%;
+      padding-right: 20px;
+      padding-left: 20px;
+      box-sizing: border-box;
+    }
+    &--right {
+      float: right;
+      width: 70%;
+    }
+  }
+}
+
+.chat-group-user {
+  padding: 0 15px;
+  line-height: 50px;
+  font-size: 14px;
+  border-bottom: 1px solid #ddd;
+  &:after {
+    content: "";
+    clear: both;
+    display: block;
+  }
+  &__name {
+    float: left;
+  }
+  &__btn {
+    float: right;
+    display: inline-block;
+    cursor: pointer;
+    &--add {
+      color: #38aef0;
+    }
+    &--remove {
+      color: #f05050;
+    }
+  }
+}

--- a/app/assets/stylesheets/module/_messages.scss
+++ b/app/assets/stylesheets/module/_messages.scss
@@ -29,6 +29,7 @@
             margin-left: 0.3rem;
             a {
               @include link_decoration_disabled($white);
+              font-size: 16px;
             }
           }
         }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,2 @@
+class GroupsController < ApplicationController
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,2 +1,10 @@
 class GroupsController < ApplicationController
+  def new
+  end
+  def create
+  end
+  def edit
+  end
+  def update
+  end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -12,7 +12,7 @@ class GroupsController < ApplicationController
         GroupUser.create(group_id: @group.id, user_id: i.to_i) unless i.empty?
       end
 
-      redirect_to root_path
+      redirect_to root_path, notice: "グループを作成しました"
     else
       render :new
     end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,13 +1,20 @@
 class GroupsController < ApplicationController
   def new
     @group = Group.new
+    @group.users << current_user
   end
 
   def create
-    group = Group.create(group_params)
-    user_ids = params.require(:group)[:user_ids]
-    user_ids.each do |i|
-      GroupUser.create(group_id: group.id, user_id: i.to_i) unless i.empty?
+    @group = Group.create(group_params)
+    if @group.errors.empty?
+      user_ids = params.require(:group)[:user_ids]
+      user_ids.each do |i|
+        GroupUser.create(group_id: @group.id, user_id: i.to_i) unless i.empty?
+      end
+
+      redirect_to root_path
+    else
+      render :new
     end
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,6 @@
 class GroupsController < ApplicationController
   def new
+    @group = Group.new
   end
   def create
   end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,4 +1,6 @@
 class GroupsController < ApplicationController
+  before_action :set_group, only: [:edit, :update]
+
   def new
     @group = Group.new
     @group.users << current_user
@@ -19,11 +21,9 @@ class GroupsController < ApplicationController
   end
 
   def edit
-    @group = Group.find(params[:id])
   end
 
   def update
-    @group = Group.find(params[:id])
     @group.update(group_params)
     if @group.errors.empty?
       redirect_to root_path, notice: "グループを更新しました"
@@ -34,5 +34,9 @@ class GroupsController < ApplicationController
 
   def group_params
     params.require(:group).permit(:name)
+  end
+
+  def set_group
+    @group = Group.find(params[:id])
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,6 +1,10 @@
 class GroupsController < ApplicationController
   before_action :set_group, only: [:edit, :update]
 
+  def index
+    @groups = current_user.groups
+  end
+
   def new
     @group = Group.new
     @group.users << current_user

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -3,9 +3,13 @@ class GroupsController < ApplicationController
     @group = Group.new
   end
   def create
+    Group.create(group_params)
   end
   def edit
   end
   def update
+  end
+  def group_params
+    params.require(:group).permit(:name)
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,6 +2,7 @@ class GroupsController < ApplicationController
   def new
     @group = Group.new
   end
+
   def create
     group = Group.create(group_params)
     user_ids = params.require(:group)[:user_ids]
@@ -9,10 +10,13 @@ class GroupsController < ApplicationController
       GroupUser.create(group_id: group.id, user_id: i.to_i) unless i.empty?
     end
   end
+
   def edit
   end
+
   def update
   end
+
   def group_params
     params.require(:group).permit(:name)
   end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -4,6 +4,7 @@ class GroupsController < ApplicationController
   end
   def create
     Group.create(group_params)
+    user_ids = params.require(:group)[:user_ids]
   end
   def edit
   end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -3,8 +3,11 @@ class GroupsController < ApplicationController
     @group = Group.new
   end
   def create
-    Group.create(group_params)
+    group = Group.create(group_params)
     user_ids = params.require(:group)[:user_ids]
+    user_ids.each do |i|
+      GroupUser.create(group_id: group.id, user_id: i.to_i) unless i.empty?
+    end
   end
   def edit
   end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -19,9 +19,17 @@ class GroupsController < ApplicationController
   end
 
   def edit
+    @group = Group.find(params[:id])
   end
 
   def update
+    @group = Group.find(params[:id])
+    @group.update(group_params)
+    if @group.errors.empty?
+      redirect_to root_path, notice: "グループを更新しました"
+    else
+      render :edit
+    end
   end
 
   def group_params

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,5 @@
 class MessagesController < ApplicationController
   def index
+    @groups = current_user.groups
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,2 +1,4 @@
 class Group < ApplicationRecord
+  has_many :group_users
+  has_many :users, through: :group_users
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,2 @@
+class Group < ApplicationRecord
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,5 @@
 class Group < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
   has_many :group_users
   has_many :users, through: :group_users
 end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,0 +1,2 @@
+class GroupUser < ApplicationRecord
+end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,2 +1,4 @@
 class GroupUser < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :group_users
+  has_many :groups, through: :group_users
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  validates :name, presence: true, uniqueness: true
   has_many :group_users
   has_many :groups, through: :group_users
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,0 +1,26 @@
+= form_for(@group) do |f|
+  - if !@group.errors.empty?
+    .chat-group-form__errors
+      %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
+      %ul
+        - @group.errors.full_messages.each do |message|
+          %li= message
+  .chat-group-form__field
+    .chat-group-form__field--left
+      = f.label :name, "グループ名", class: "chat-group-form__label"
+      -# %label.chat-group-form__label{for: "chat_group_name"} グループ名
+    .chat-group-form__field--right
+      = f.text_field :name, autofocus: true, class: "chat-group-form__input", placeholder: "グループ名を入力してください"
+      -# %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
+  .chat-group-form__field
+    / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
+  .chat-group-form__field
+    .chat-group-form__field--left
+      %label.chat-group-form__label チャットメンバー
+    .chat-group-form__field--right
+      = f.collection_check_boxes :user_ids, User.all, :id, :name
+      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
+  .chat-group-form__field
+    .chat-group-form__field--left
+    .chat-group-form__field--right
+      %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,0 +1,25 @@
+.chat-group-form
+  %h1 チャットグループ編集
+  %form
+    .chat-group-form__errors
+      %h2
+        1件のエラーが発生しました。
+        %ul
+          %li エラーです
+    .chat-group-form__field
+      .chat-group-form__field--left
+        %label.chat-group-form__label{:for => "chat_group_name"} グループ名
+      .chat-group-form__field--right
+        %input#chat_group_name.chat-group-form__input{:name => "chat_group[name]", :placeholder => "グループ名を入力してください", :type => "text"}/
+    .chat-group-form__field
+      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
+    .chat-group-form__field
+      .chat-group-form__field--left
+        %label.chat-group-form__label チャットメンバー
+      .chat-group-form__field--right
+        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
+    .chat-group-form__field
+      .chat-group-form__field--left
+      .chat-group-form__field--right
+        %input.chat-group-form__action-btn{"data-disable-with" => "Save", :name => "commit", :type => "submit", :value => "Save"}/

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -8,9 +8,9 @@
           %li エラーです
     .chat-group-form__field
       .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_name"} グループ名
+        %label.chat-group-form__label{for: "chat_group_name"} グループ名
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{:name => "chat_group[name]", :placeholder => "グループ名を入力してください", :type => "text"}/
+        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
     .chat-group-form__field
       / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
     .chat-group-form__field
@@ -22,4 +22,4 @@
     .chat-group-form__field
       .chat-group-form__field--left
       .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with" => "Save", :name => "commit", :type => "submit", :value => "Save"}/
+        %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,28 +1,3 @@
 .chat-group-form
   %h1 チャットグループ編集
-  = form_for(@group) do |f|
-    - if !@group.errors.empty?
-      .chat-group-form__errors
-        %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
-        %ul
-          - @group.errors.full_messages.each do |message|
-            %li= message
-    .chat-group-form__field
-      .chat-group-form__field--left
-        = f.label :name, "グループ名", class: "chat-group-form__label"
-        -# %label.chat-group-form__label{for: "chat_group_name"} グループ名
-      .chat-group-form__field--right
-        = f.text_field :name, autofocus: true, class: "chat-group-form__input", placeholder: "グループ名を入力してください"
-        -# %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
-    .chat-group-form__field
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label チャットメンバー
-      .chat-group-form__field--right
-        = f.collection_check_boxes :user_ids, User.all, :id, :name
-        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/
+  = render partial: "form"

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,23 +1,26 @@
 .chat-group-form
   %h1 チャットグループ編集
-  %form
-    .chat-group-form__errors
-      %h2
-        1件のエラーが発生しました。
+  = form_for(@group) do |f|
+    - if !@group.errors.empty?
+      .chat-group-form__errors
+        %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
         %ul
-          %li エラーです
+          - @group.errors.full_messages.each do |message|
+            %li= message
     .chat-group-form__field
       .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
+        = f.label :name, "グループ名", class: "chat-group-form__label"
+        -# %label.chat-group-form__label{for: "chat_group_name"} グループ名
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
+        = f.text_field :name, autofocus: true, class: "chat-group-form__input", placeholder: "グループ名を入力してください"
+        -# %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
     .chat-group-form__field
       / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
     .chat-group-form__field
       .chat-group-form__field--left
         %label.chat-group-form__label チャットメンバー
       .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+        = f.collection_check_boxes :user_ids, User.all, :id, :name
         / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
     .chat-group-form__field
       .chat-group-form__field--left

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,0 +1,2 @@
+.wrapper
+  = render partial: "shared/sidebar"

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,0 +1,25 @@
+.chat-group-form
+  %h1 新規チャットグループ
+  %form
+    .chat-group-form__errors
+      %h2
+        1件のエラーが発生しました。
+        %ul
+          %li エラーです
+    .chat-group-form__field
+      .chat-group-form__field--left
+        %label.chat-group-form__label{:for => "chat_group_name"} グループ名
+      .chat-group-form__field--right
+        %input#chat_group_name.chat-group-form__input{:name => "chat_group[name]", :placeholder => "グループ名を入力してください", :type => "text"}/
+    .chat-group-form__field
+      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
+    .chat-group-form__field
+      .chat-group-form__field--left
+        %label.chat-group-form__label チャットメンバー
+      .chat-group-form__field--right
+        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
+    .chat-group-form__field
+      .chat-group-form__field--left
+      .chat-group-form__field--right
+        %input.chat-group-form__action-btn{"data-disable-with" => "Save", :name => "commit", :type => "submit", :value => "Save"}/

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -8,9 +8,9 @@
           %li エラーです
     .chat-group-form__field
       .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_name"} グループ名
+        %label.chat-group-form__label{for: "chat_group_name"} グループ名
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{:name => "chat_group[name]", :placeholder => "グループ名を入力してください", :type => "text"}/
+        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
     .chat-group-form__field
       / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
     .chat-group-form__field
@@ -22,4 +22,4 @@
     .chat-group-form__field
       .chat-group-form__field--left
       .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with" => "Save", :name => "commit", :type => "submit", :value => "Save"}/
+        %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,28 +1,3 @@
 .chat-group-form
   %h1 新規チャットグループ
-  = form_for(@group) do |f|
-    - if !@group.errors.empty?
-      .chat-group-form__errors
-        %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
-        %ul
-          - @group.errors.full_messages.each do |message|
-            %li= message
-    .chat-group-form__field
-      .chat-group-form__field--left
-        = f.label :name, "グループ名", class: "chat-group-form__label"
-        -# %label.chat-group-form__label{for: "chat_group_name"} グループ名
-      .chat-group-form__field--right
-        = f.text_field :name, autofocus: true, class: "chat-group-form__input", placeholder: "グループ名を入力してください"
-        -# %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
-    .chat-group-form__field
-      / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-        %label.chat-group-form__label チャットメンバー
-      .chat-group-form__field--right
-        = f.collection_check_boxes :user_ids, User.all, :id, :name
-        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
-    .chat-group-form__field
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/
+  = render partial: "form"

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -8,9 +8,11 @@
           %li エラーです
     .chat-group-form__field
       .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
+        = f.label :name, "グループ名", class: "chat-group-form__label"
+        -# %label.chat-group-form__label{for: "chat_group_name"} グループ名
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
+        = f.text_field :name, autofocus: true, class: "chat-group-form__input", placeholder: "グループ名を入力してください"
+        -# %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
     .chat-group-form__field
       / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
     .chat-group-form__field

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -19,7 +19,7 @@
       .chat-group-form__field--left
         %label.chat-group-form__label チャットメンバー
       .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+        = f.collection_check_boxes :user_ids, User.all, :id, :name
         / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
     .chat-group-form__field
       .chat-group-form__field--left

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,11 +1,12 @@
 .chat-group-form
   %h1 新規チャットグループ
   = form_for(@group) do |f|
-    .chat-group-form__errors
-      %h2
-        1件のエラーが発生しました。
+    - if !@group.errors.empty?
+      .chat-group-form__errors
+        %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
         %ul
-          %li エラーです
+          - @group.errors.full_messages.each do |message|
+            %li= message
     .chat-group-form__field
       .chat-group-form__field--left
         = f.label :name, "グループ名", class: "chat-group-form__label"

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,6 +1,6 @@
 .chat-group-form
   %h1 新規チャットグループ
-  %form
+  = form_for(@group) do |f|
     .chat-group-form__errors
       %h2
         1件のエラーが発生しました。

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,22 +1,5 @@
 .wrapper
-  .sidebar
-    .sidebar-header
-      .sidebar-header__content
-        %p.sidebar-header__content__current-username
-          = current_user.name
-        %ul.sidebar-header__content__menu
-          %li.sidebar-header__content__menu__btn-create-group
-            = link_to new_group_path do
-              = fa_icon 'edit'
-          %li.sidebar-header__content__menu__btn-edit-account
-            = link_to edit_user_path(current_user) do
-              = fa_icon 'cog'
-    .grouplist
-      - @groups.each do |group|
-        = link_to "#" do
-          .group
-            %p.group__name=group.name
-            %p.group__message こんにちは
+  = render partial: "shared/sidebar"
   .main
     .main-header
       .main-header__left

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -12,18 +12,11 @@
             = link_to edit_user_path(current_user) do
               = fa_icon 'cog'
     .grouplist
-      = link_to "#" do
-        .group
-          %p.group__name グループA
-          %p.group__message こんにちは
-      = link_to "#" do
-        .group
-          %p.group__name グループB
-          %p.group__message 画像が投稿されました
-      = link_to "#" do
-        .group
-          %p.group__name グループC
-          %p.group__message まだメッセージがありません
+      - @groups.each do |group|
+        = link_to "#" do
+          .group
+            %p.group__name=group.name
+            %p.group__message こんにちは
   .main
     .main-header
       .main-header__left

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -6,7 +6,7 @@
           = current_user.name
         %ul.sidebar-header__content__menu
           %li.sidebar-header__content__menu__btn-create-group
-            = link_to "#" do
+            = link_to new_group_path do
               = fa_icon 'edit'
           %li.sidebar-header__content__menu__btn-edit-account
             = link_to edit_user_path(current_user) do

--- a/app/views/shared/_sidebar.html.haml
+++ b/app/views/shared/_sidebar.html.haml
@@ -1,0 +1,18 @@
+.sidebar
+  .sidebar-header
+    .sidebar-header__content
+      %p.sidebar-header__content__current-username
+        = current_user.name
+      %ul.sidebar-header__content__menu
+        %li.sidebar-header__content__menu__btn-create-group
+          = link_to new_group_path do
+            = fa_icon 'edit'
+        %li.sidebar-header__content__menu__btn-edit-account
+          = link_to edit_user_path(current_user) do
+            = fa_icon 'cog'
+  .grouplist
+    - @groups.each do |group|
+      = link_to "#" do
+        .group
+          %p.group__name=group.name
+          %p.group__message こんにちは

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  root to: "messages#index"
+  root to: "groups#index"
   resources :users, only: ["edit", "update"]
   resources :groups, only: ["edit", "update", "new", "create"]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "messages#index"
   resources :users, only: ["edit", "update"]
+  resources :groups, only: ["edit", "update", "new", "create"]
 end

--- a/db/migrate/20191029114204_create_groups.rb
+++ b/db/migrate/20191029114204_create_groups.rb
@@ -1,0 +1,8 @@
+class CreateGroups < ActiveRecord::Migration[5.0]
+  def change
+    create_table :groups do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191029114204_create_groups.rb
+++ b/db/migrate/20191029114204_create_groups.rb
@@ -1,7 +1,7 @@
 class CreateGroups < ActiveRecord::Migration[5.0]
   def change
     create_table :groups do |t|
-
+      t.string :name, null: false, unique: true, index: true
       t.timestamps
     end
   end

--- a/db/migrate/20191029114732_create_group_users.rb
+++ b/db/migrate/20191029114732_create_group_users.rb
@@ -1,7 +1,8 @@
 class CreateGroupUsers < ActiveRecord::Migration[5.0]
   def change
     create_table :group_users do |t|
-
+      t.references :group, foreign_key: true
+      t.references :user, foreign_key: true
       t.timestamps
     end
   end

--- a/db/migrate/20191029114732_create_group_users.rb
+++ b/db/migrate/20191029114732_create_group_users.rb
@@ -1,0 +1,8 @@
+class CreateGroupUsers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :group_users do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191028124422) do
+ActiveRecord::Schema.define(version: 20191029114732) do
+
+  create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "group_id"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_group_users_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_group_users_on_user_id", using: :btree
+  end
+
+  create_table "groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_groups_on_name", using: :btree
+  end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",                                null: false
@@ -26,4 +42,6 @@ ActiveRecord::Schema.define(version: 20191028124422) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "group_users", "groups"
+  add_foreign_key "group_users", "users"
 end


### PR DESCRIPTION
# what
- chatspaceアプリケーションのユーザー管理機能を実装する。
- グループ編集機能の実装。
- モデルのバリデーションにより、適切なグループ名のみを受け付ける機能の実装。
- バリデーションの失敗をエラーメッセージとしてビューに表示する。
- バリデーションの成功をフラッシュメッセージとしてトップページに表示する。
- 作成したグループをトップページに表示する。
# why
- グループ機能はチャットアプリに不可欠なため。
- バリデーションの結果を利用者に見やすく表示することがユーザーにとっての利便性につながるため。