### PR TITLE
chatspaceのメッセージ機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "haml-rails", ">= 1.0", '<= 2.0.1'
 gem "font-awesome-rails"
 gem 'devise'
+gem 'carrierwave'
 
 group :development, :test do
   # 以下はvscodeの拡張用

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem "haml-rails", ">= 1.0", '<= 2.0.1'
 gem "font-awesome-rails"
 gem 'devise'
 gem 'carrierwave'
+gem 'mini_magick'
 
 group :development, :test do
   # 以下はvscodeの拡張用

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arel (7.1.4)
     ast (2.4.0)
     axiom-types (0.1.1)
@@ -49,6 +51,13 @@ GEM
     bindex (0.8.1)
     builder (3.2.3)
     byebug (11.0.1)
+    carrierwave (2.0.2)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     codeclimate-engine-rb (0.4.1)
       virtus (~> 1.0)
     coderay (1.1.2)
@@ -106,6 +115,9 @@ GEM
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    image_processing (1.9.3)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.13, < 3)
     jaro_winkler (1.5.3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
@@ -123,6 +135,8 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.2)
+    mimemagic (0.3.3)
+    mini_magick (4.9.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.12.2)
@@ -141,6 +155,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     psych (3.1.0)
+    public_suffix (4.0.1)
     puma (3.12.1)
     rack (2.0.7)
     rack-test (0.6.3)
@@ -198,6 +213,8 @@ GEM
       parser (~> 2.2)
       slop (~> 3.4, >= 3.4.7)
     ruby-progressbar (1.10.1)
+    ruby-vips (2.0.16)
+      ffi (~> 1.9)
     ruby_parser (3.14.0)
       sexp_processor (~> 4.9)
     sass (3.7.4)
@@ -270,6 +287,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  carrierwave
   coffee-rails (~> 4.2)
   debase
   debride

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,6 +299,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
+  mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
   pry-rails
   puma (~> 3.0)

--- a/app/assets/stylesheets/module/_messages.scss
+++ b/app/assets/stylesheets/module/_messages.scss
@@ -166,6 +166,9 @@
                 cursor: pointer;
               }
             }
+            &__input {
+              display: none;
+            }
           }
         }
         &__btn-submit {

--- a/app/assets/stylesheets/module/_messages.scss
+++ b/app/assets/stylesheets/module/_messages.scss
@@ -155,7 +155,7 @@
             height: 50px;
             @include reset_border_width;
           }
-          .upload-label {
+          &__img-upload {
             position: absolute;
             top: 0;
             right: 10px;

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,4 +2,7 @@ class MessagesController < ApplicationController
   def index
     @groups = current_user.groups
   end
+
+  def create
+  end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,6 +2,7 @@ class MessagesController < ApplicationController
   def index
     @groups = current_user.groups
     @group = Group.find(params[:group_id])
+    @message = Message.new
   end
 
   def create

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,9 +7,10 @@ class MessagesController < ApplicationController
   def create
     message = Message.create(message_params)
     if message.errors.empty?
-      render :index
+      redirect_to group_messages_path(params[:group_id]), notice: "メッセージを送信しました"
     else
-      redirect_to group_messages_path(params[:group_id]), alert: "メッセージを入力してください"
+      flash[:alert] = "メッセージを入力してください"
+      render :index
     end
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -20,6 +20,7 @@ class MessagesController < ApplicationController
   def set_message
     @groups = current_user.groups
     @group = Group.find(params[:group_id])
+    @messages = @group.messages.includes(:user)
     @message = Message.new
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -6,7 +6,8 @@ class MessagesController < ApplicationController
   end
 
   def create
-    Message.create(message_params)
+    message = Message.create(message_params)
+    render :index if message.errors.empty?
   end
 
   def message_params

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,6 +1,7 @@
 class MessagesController < ApplicationController
   def index
     @groups = current_user.groups
+    @group = Group.find(params[:group_id])
   end
 
   def create

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -6,5 +6,10 @@ class MessagesController < ApplicationController
   end
 
   def create
+    Message.create(message_params)
+  end
+
+  def message_params
+    params.require(:message).permit(:content).merge(group_id: params[:group_id], user_id: current_user.id)
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,8 +1,7 @@
 class MessagesController < ApplicationController
+  before_action :set_message, only: [:index, :create]
+
   def index
-    @groups = current_user.groups
-    @group = Group.find(params[:group_id])
-    @message = Message.new
   end
 
   def create
@@ -12,5 +11,11 @@ class MessagesController < ApplicationController
 
   def message_params
     params.require(:message).permit(:content).merge(group_id: params[:group_id], user_id: current_user.id)
+  end
+
+  def set_message
+    @groups = current_user.groups
+    @group = Group.find(params[:group_id])
+    @message = Message.new
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -14,7 +14,7 @@ class MessagesController < ApplicationController
   end
 
   def message_params
-    params.require(:message).permit(:content).merge(group_id: params[:group_id], user_id: current_user.id)
+    params.require(:message).permit(:content, :image).merge(group_id: params[:group_id], user_id: current_user.id)
   end
 
   def set_message

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -6,7 +6,11 @@ class MessagesController < ApplicationController
 
   def create
     message = Message.create(message_params)
-    render :index if message.errors.empty?
+    if message.errors.empty?
+      render :index
+    else
+      redirect_to group_messages_path(params[:group_id]), alert: "メッセージを入力してください"
+    end
   end
 
   def message_params

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,4 +2,5 @@ class Group < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   has_many :group_users
   has_many :users, through: :group_users
+  has_many :messages
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,15 @@ class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
   has_many :messages
+
+  def show_last_message
+    unless defined? messages.last.content
+      return "まだ投稿がありません"
+    end
+    if messages.last.content.empty?
+      return "画像が投稿されています"
+    else
+      return messages.last.content
+    end
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,2 @@
+class Message < ApplicationRecord
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,2 +1,4 @@
 class Message < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,6 @@
 class Message < ApplicationRecord
   belongs_to :group
   belongs_to :user
+
+  validates :content, presence: true, unless: :image?
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,5 @@
 class Message < ApplicationRecord
+  mount_uploader :image, ImagesUploader
   belongs_to :group
   belongs_to :user
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   has_many :group_users
   has_many :groups, through: :group_users
+  has_many :messages
 end

--- a/app/uploaders/images_uploader.rb
+++ b/app/uploaders/images_uploader.rb
@@ -1,0 +1,47 @@
+class ImagesUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/uploaders/images_uploader.rb
+++ b/app/uploaders/images_uploader.rb
@@ -6,6 +6,8 @@ class ImagesUploader < CarrierWave::Uploader::Base
   # Choose what kind of storage to use for this uploader:
   storage :file
   # storage :fog
+  include CarrierWave::MiniMagick
+  process resize_to_fit: [200, 200]
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,0 +1,6 @@
+.chat__message
+  .chat__message__info
+    .chat__message__info__username=message.user.name
+    .chat__message__info__date=message.updated_at.strftime("%Y/%m/%d %H:%M")
+  .chat__message__text=message.content
+  = image_tag message.image.to_s

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -17,7 +17,7 @@
             .chat__message__info__username=message.user.name
             .chat__message__info__date=message.updated_at
           .chat__message__text=message.content
-          = image_tag message.image
+          = image_tag message.image.to_s
     .main-bottom
       = form_for([@group, @message], html: {class: "chat-form"}) do |f|
         .chat-form__content

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -11,7 +11,7 @@
       = link_to edit_group_path(@group.id) do
         .main-header__btn-edit-group Edit
     .chat
-      - @group.messages.each do |message|
+      - @messages.each do |message|
         .chat__message
           .chat__message__info
             .chat__message__info__username=message.user.name

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -22,5 +22,5 @@
         .chat-form__content
           = f.text_field :content, class: "chat-form__content__message", placeholder: "type a message"
           %label.upload-label{for: "upload-icon"}
-            %i.fa.fa-picture-o
+            = fa_icon "picture-o"
         %input.chat-form__btn-submit{type: "submit", value: "Send"}

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -17,6 +17,7 @@
             .chat__message__info__username=message.user.name
             .chat__message__info__date=message.updated_at
           .chat__message__text=message.content
+          = image_tag message.image
     .main-bottom
       = form_for([@group, @message], html: {class: "chat-form"}) do |f|
         .chat-form__content

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -15,7 +15,7 @@
         .chat__message
           .chat__message__info
             .chat__message__info__username=message.user.name
-            .chat__message__info__date=message.updated_at
+            .chat__message__info__date=message.updated_at.strftime("%Y/%m/%d %H:%M")
           .chat__message__text=message.content
           = image_tag message.image.to_s
     .main-bottom

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -6,9 +6,8 @@
         %p.main-header__left__group-name=@group.name
         %ul.main-header__left__member-list
           Member：
-          %li.main-header__left__member-list__member 山田
-          %li.main-header__left__member-list__member 田中
-          %li.main-header__left__member-list__member 鈴木
+          - @group.users.each do |user|
+            %li.main-header__left__member-list__member=user.name
       = link_to "#" do
         .main-header__btn-edit-group Edit
     .chat

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -11,13 +11,7 @@
       = link_to edit_group_path(@group.id) do
         .main-header__btn-edit-group Edit
     .chat
-      - @messages.each do |message|
-        .chat__message
-          .chat__message__info
-            .chat__message__info__username=message.user.name
-            .chat__message__info__date=message.updated_at.strftime("%Y/%m/%d %H:%M")
-          .chat__message__text=message.content
-          = image_tag message.image.to_s
+      = render partial: "message", collection: @messages
     .main-bottom
       = form_for([@group, @message], html: {class: "chat-form"}) do |f|
         .chat-form__content

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -27,7 +27,7 @@
           .chat__message__info__date 2019/10/22(Tue) 21:30:06
         .chat__message__text よろしくお願いします
     .main-bottom
-      %form.chat-form
+      = form_for([@group, @message], html: {class: "chat-form"}) do |f|
         .chat-form__content
           %input.chat-form__content__message{type: "text", placeholder: "type a message"}
           %label.upload-label{for: "upload-icon"}

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -3,7 +3,7 @@
   .main
     .main-header
       .main-header__left
-        %p.main-header__left__group-name グループA
+        %p.main-header__left__group-name=@group.name
         %ul.main-header__left__member-list
           Member：
           %li.main-header__left__member-list__member 山田

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -11,21 +11,12 @@
       = link_to edit_group_path(@group.id) do
         .main-header__btn-edit-group Edit
     .chat
-      .chat__message
-        .chat__message__info
-          .chat__message__info__username 山田
-          .chat__message__info__date 2019/10/22(Tue) 21:30:06
-        .chat__message__text はじめまして
-      .chat__message
-        .chat__message__info
-          .chat__message__info__username 田中
-          .chat__message__info__date 2019/10/22(Tue) 21:30:06
-        .chat__message__text こんにちは
-      .chat__message
-        .chat__message__info
-          .chat__message__info__username 鈴木
-          .chat__message__info__date 2019/10/22(Tue) 21:30:06
-        .chat__message__text よろしくお願いします
+      - @group.messages.each do |message|
+        .chat__message
+          .chat__message__info
+            .chat__message__info__username=message.user.name
+            .chat__message__info__date=message.updated_at
+          .chat__message__text=message.content
     .main-bottom
       = form_for([@group, @message], html: {class: "chat-form"}) do |f|
         .chat-form__content

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -23,4 +23,5 @@
           = f.text_field :content, class: "chat-form__content__message", placeholder: "type a message"
           = f.label :image, class: "chat-form__content__img-upload" do
             = fa_icon "picture-o"
+            = f.file_field :image, class: "chat-form__content__img-upload__input"
         %input.chat-form__btn-submit{type: "submit", value: "Send"}

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -21,6 +21,6 @@
       = form_for([@group, @message], html: {class: "chat-form"}) do |f|
         .chat-form__content
           = f.text_field :content, class: "chat-form__content__message", placeholder: "type a message"
-          %label.chat-form__content__img-upload{for: "upload-icon"}
+          = f.label :image, class: "chat-form__content__img-upload" do
             = fa_icon "picture-o"
         %input.chat-form__btn-submit{type: "submit", value: "Send"}

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -8,7 +8,7 @@
           Member：
           - @group.users.each do |user|
             %li.main-header__left__member-list__member=user.name
-      = link_to "#" do
+      = link_to edit_group_path(@group.id) do
         .main-header__btn-edit-group Edit
     .chat
       .chat__message

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -29,7 +29,7 @@
     .main-bottom
       = form_for([@group, @message], html: {class: "chat-form"}) do |f|
         .chat-form__content
-          %input.chat-form__content__message{type: "text", placeholder: "type a message"}
+          = f.text_field :content, class: "chat-form__content__message", placeholder: "type a message"
           %label.upload-label{for: "upload-icon"}
             %i.fa.fa-picture-o
         %input.chat-form__btn-submit{type: "submit", value: "Send"}

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -21,6 +21,6 @@
       = form_for([@group, @message], html: {class: "chat-form"}) do |f|
         .chat-form__content
           = f.text_field :content, class: "chat-form__content__message", placeholder: "type a message"
-          %label.upload-label{for: "upload-icon"}
+          %label.chat-form__content__img-upload{for: "upload-icon"}
             = fa_icon "picture-o"
         %input.chat-form__btn-submit{type: "submit", value: "Send"}

--- a/app/views/shared/_sidebar.html.haml
+++ b/app/views/shared/_sidebar.html.haml
@@ -15,4 +15,4 @@
       = link_to group_messages_path(group.id) do
         .group
           %p.group__name=group.name
-          %p.group__message こんにちは
+          %p.group__message=group.show_last_message

--- a/app/views/shared/_sidebar.html.haml
+++ b/app/views/shared/_sidebar.html.haml
@@ -12,7 +12,7 @@
             = fa_icon 'cog'
   .grouplist
     - @groups.each do |group|
-      = link_to "#" do
+      = link_to group_messages_path(group.id) do
         .group
           %p.group__name=group.name
           %p.group__message こんにちは

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "groups#index"
   resources :users, only: ["edit", "update"]
-  resources :groups, only: ["edit", "update", "new", "create"]
+  resources :groups, only: ["edit", "update", "new", "create"] do
+    resources :messages, only: ["index", "create"]
+  end
 end

--- a/db/migrate/20191031012302_create_messages.rb
+++ b/db/migrate/20191031012302_create_messages.rb
@@ -1,0 +1,8 @@
+class CreateMessages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :messages do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191031012302_create_messages.rb
+++ b/db/migrate/20191031012302_create_messages.rb
@@ -1,7 +1,10 @@
 class CreateMessages < ActiveRecord::Migration[5.0]
   def change
     create_table :messages do |t|
-
+      t.string :content
+      t.string :image
+      t.references :group, foreign_key: true
+      t.references :user, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191029114732) do
+ActiveRecord::Schema.define(version: 20191031012302) do
 
   create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "group_id"
@@ -26,6 +26,17 @@ ActiveRecord::Schema.define(version: 20191029114732) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_groups_on_name", using: :btree
+  end
+
+  create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "content"
+    t.string   "image"
+    t.integer  "group_id"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_messages_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_messages_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -44,4 +55,6 @@ ActiveRecord::Schema.define(version: 20191029114732) do
 
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
+  add_foreign_key "messages", "groups"
+  add_foreign_key "messages", "users"
 end


### PR DESCRIPTION
# what
- chatspaceアプリケーションのメッセージ送信機能を実装する。
- messagesモデルを作成し、usersとgroupモデルとのアソシエーションを組む。
- messageモデルのバリデーションの成否をフラッシュメッセージで表示する。
- ルーティングのネストにより、グループごとにメッセージ表示・投稿画面を分ける。
- carrierwaveを使って画像の投稿機能を実装する。
- mini_magickにより投稿された画像をリサイズする。
- サイドバーにgroupの最新のメッセージを表示する。    
# why
- メッセージ投稿機能はチャットアプリに不可欠なため。
- 画像投稿も可能なことで利用者にとっての満足度の向上が期待できる。
- バリデーションの結果を利用者に見やすく表示することがユーザーにとっての利便性につながるため。