### PR TITLE
chatspaceのメッセージ送信の非同期通信による実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -35,8 +35,7 @@ $(document).on("turbolinks:load", function() {
         var html = buildHTML(data);
         var chat = $(".chat");
         chat.append(html);
-        $("#message_content").val("");
-        $("#message_image").val("");
+        $("#new_message")[0].reset();
         chat.animate({ scrollTop: chat[0].scrollHeight }, 100);
       })
       .fail(function() {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,23 @@
+var $;
+$(function() {
+  $("#new_message").on("submit", function(e) {
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr("action");
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: "json",
+      processData: false,
+      contentType: false
+    })
+      .done(function(data) {
+        console.log(data);
+      })
+      .fail(function() {
+        alert("メッセージ送信に失敗しました");
+      });
+    return false;
+  });
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -37,6 +37,7 @@ $(function() {
         chat.append(html);
         $("#message_content").val("");
         $("#message_image").val("");
+        chat.animate({ scrollTop: chat[0].scrollHeight }, 100);
       })
       .fail(function() {
         alert("メッセージ送信に失敗しました");

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,5 +1,5 @@
 var $;
-$(function() {
+$(document).on("turbolinks:load", function() {
   function buildHTML(message) {
     var image_tag = message.image_url
       ? `<img src="${message.image_url}" alt="${message.image_alt}">`

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -21,7 +21,7 @@ $(function() {
   $("#new_message").on("submit", function(e) {
     e.preventDefault();
     var formData = new FormData(this);
-    var url = $(this).attr("action");
+    var url = this.action;
     $.ajax({
       url: url,
       type: "POST",

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -35,6 +35,8 @@ $(function() {
         var html = buildHTML(data);
         var chat = $(".chat");
         chat.append(html);
+        $("#message_content").val("");
+        $("#message_image").val("");
       })
       .fail(function() {
         alert("メッセージ送信に失敗しました");

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -20,6 +20,7 @@ $(function() {
 
   $("#new_message").on("submit", function(e) {
     e.preventDefault();
+    $(this).prop("disabled", true);
     var formData = new FormData(this);
     var url = this.action;
     $.ajax({
@@ -31,7 +32,6 @@ $(function() {
       contentType: false
     })
       .done(function(data) {
-        console.log(data);
         var html = buildHTML(data);
         var chat = $(".chat");
         chat.append(html);
@@ -42,6 +42,5 @@ $(function() {
       .fail(function() {
         alert("メッセージ送信に失敗しました");
       });
-    return false;
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,5 +1,23 @@
 var $;
 $(function() {
+  function buildHTML(message) {
+    var image_tag = message.image_url
+      ? `<img src="${message.image_url}" alt="${message.image_alt}">`
+      : "";
+
+    var html = `
+    <div class="chat__message">
+      <div class="chat__message__info">
+        <div class="chat__message__info__username">${message.user_name}</div>
+        <div class="chat__message__info__date">${message.updated_at}</div>
+      </div>
+      <div class="chat__message__text">${message.content}</div>
+      ${image_tag}
+    </div>
+    `;
+    return html;
+  }
+
   $("#new_message").on("submit", function(e) {
     e.preventDefault();
     var formData = new FormData(this);
@@ -14,6 +32,9 @@ $(function() {
     })
       .done(function(data) {
         console.log(data);
+        var html = buildHTML(data);
+        var chat = $(".chat");
+        chat.append(html);
       })
       .fail(function() {
         alert("メッセージ送信に失敗しました");

--- a/app/assets/stylesheets/module/_messages.scss
+++ b/app/assets/stylesheets/module/_messages.scss
@@ -106,11 +106,11 @@
       flex-grow: 1;
       background-color: #fafafa;
       border: 1px solid #eeeeee;
-      padding: 0 $chat_block_padding_length;
+      padding: 46px $chat_block_padding_length 0;
       overflow: scroll;
       @include hide_scrollbar;
       &__message {
-        padding-top: 46px;
+        padding-bottom: 40px;
         &__info {
           margin-bottom: 10px;
           display: flex;

--- a/app/assets/stylesheets/module/_messages.scss
+++ b/app/assets/stylesheets/module/_messages.scss
@@ -154,6 +154,7 @@
             width: 100%;
             height: 50px;
             @include reset_border_width;
+            outline: 0;
           }
           &__img-upload {
             position: absolute;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -36,6 +36,8 @@ class GroupsController < ApplicationController
     end
   end
 
+  private
+
   def group_params
     params.require(:group).permit(:name)
   end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -5,12 +5,19 @@ class MessagesController < ApplicationController
   end
 
   def create
-    message = Message.create(message_params)
-    if message.errors.empty?
-      redirect_to group_messages_path(params[:group_id]), notice: "メッセージを送信しました"
-    else
-      flash[:alert] = "メッセージを入力してください"
-      render :index
+    @new_message = Message.create(message_params)
+
+    respond_to do |format|
+      format.html do
+        if @new_message.errors.empty?
+          redirect_to group_messages_path(params[:group_id]), notice: "メッセージを送信しました"
+        else
+          flash[:alert] = "メッセージを入力してください"
+          render :index
+        end
+      end
+
+      format.json
     end
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -21,6 +21,8 @@ class MessagesController < ApplicationController
     end
   end
 
+  private
+
   def message_params
     params.require(:message).permit(:content, :image).merge(group_id: params[:group_id], user_id: current_user.id)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,8 @@ class UsersController < ApplicationController
     end
   end
 
+  private
+
   def user_params
     params.require(:user).permit(:name, :email)
   end

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
 json.user_name @new_message.user.name
-json.updated_at @new_message.updated_at.strftime("%Y/%m/%d %H:%M")
+json.updated_at @new_message.updated_at.strftime("%Y/%m/%d(%a) %H:%M")
 json.content @new_message.content
 json.image_url @new_message.image_url
 json.image_alt @new_message.image.identifier

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,5 @@
+json.user_name @new_message.user.name
+json.updated_at @new_message.updated_at.strftime("%Y/%m/%d %H:%M")
+json.content @new_message.content
+json.image_url @new_message.image_url
+json.image_alt @new_message.image.identifier

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ Bundler.require(*Rails.groups)
 module ChatSpace
   class Application < Rails::Application
     config.i18n.default_locale = :ja
+    config.time_zone = "Asia/Tokyo"
     config.generators do |g|
       g.stylesheets false
       g.javascripts false


### PR DESCRIPTION
# what
- chatspaceでのメッセージ送信を非同期通信に変更する。
- メッセージの送信イベントが起きたら、jqueryのajax機能でメッセージを送信する。
    - 送信のイベントをpreventDefaultで抑止する。
    - jqueryのajaxメソッドでFormDataを送信する。
    - フォームのdisabled属性をtrueにして、連続送信できるようにする。
- サーバー側にメッセージが届いたとき、リクエストに応じてhtmlまたはjsonを返す。
- jbuilderを使用し、レスポンスのデータを適切なjson形式で送信する。
- jquery.ajaxのdoneメソッドでjsonレスポンスを受け取ったら、データをhtmlに埋め込む。
    - データの埋め込みには、JavaScriptのテンプレートリテラルを使う。
    - 三項演算子を適用し、画像の有無に応じて埋め込むテンプレートを切り替える。
- データをhtmlに埋め込んだら、jqueryのanimateメソッドで最新のメッセージまでスクロールする。
- jqueryのfailメソッドで、非同期通信が失敗したらalertを出す。
- jquery.readyのコールバックを、turbolinks:loadイベントに対応させる。turbolinksによってdocumentの読み込みが省略されてイベントが発火しなくなる問題へ対処する。
# why
- 非同期通信によりページ全体の読み込みが省略されるため、メッセージ送受信での画面の再描画を高速化できるから。
- jbuilderを用いることで、レスポンスのデータ整形を見通しよくできるから。
- メッセージ画面のスクロールによって、利用者にとってメッセージを読みやすくできるから。
# 実装の内容の動作状況の動画
- 画像のみ、テキストのみを投稿：[キャプチャ動画 - 7bd05ef7740d742269162ded0fda5bdc - Gyazo](https://gyazo.com/7bd05ef7740d742269162ded0fda5bdc)
- 画像とテキストを投稿：[キャプチャ動画 - a5642f9659736c81588b072d9b9372a9 - Gyazo](https://gyazo.com/a5642f9659736c81588b072d9b9372a9)
- メッセージと画像がどちらもないとエラーメッセージを表示：[キャプチャ動画 - 6224fa289dd557aa86dff7935e3ce19b - Gyazo](https://gyazo.com/6224fa289dd557aa86dff7935e3ce19b)