### PR TITLE
chatspaceのメッセージ自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -6,7 +6,6 @@ $(document).on("turbolinks:load", function() {
       : "";
 
     var html = `
-    <div class="chat__message">
     <div class="chat__message" data-message-id="${message.message_id}">
       <div class="chat__message__info">
         <div class="chat__message__info__username">${message.user_name}</div>

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,5 +1,12 @@
 var $;
 $(document).on("turbolinks:load", function() {
+  function isChatUrl(pathname) {
+    var urlPatternChatView = /\/groups\/\d+\/messages/;
+    if (pathname.match(urlPatternChatView)) {
+      return true;
+    }
+  }
+
   function buildHTML(message) {
     var image_tag = message.image_url
       ? `<img src="${message.image_url}" alt="${message.image_alt}">`

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -18,31 +18,6 @@ $(document).on("turbolinks:load", function() {
     return html;
   }
 
-  $("#new_message").on("submit", function(e) {
-    e.preventDefault();
-    $(this).prop("disabled", true);
-    var formData = new FormData(this);
-    var url = this.action;
-    $.ajax({
-      url: url,
-      type: "POST",
-      data: formData,
-      dataType: "json",
-      processData: false,
-      contentType: false
-    })
-      .done(function(data) {
-        var html = buildHTML(data);
-        var chat = $(".chat");
-        chat.append(html);
-        $("#new_message")[0].reset();
-        chat.animate({ scrollTop: chat[0].scrollHeight }, 100);
-      })
-      .fail(function() {
-        alert("メッセージ送信に失敗しました");
-      });
-  });
-
   function updateMessages() {
     var last_message = $(".chat__message").last();
     var latest_message_id = last_message.data("message-id");
@@ -69,6 +44,31 @@ $(document).on("turbolinks:load", function() {
         alert("データの取得に失敗しました");
       });
   }
+
+  $("#new_message").on("submit", function(e) {
+    e.preventDefault();
+    $(this).prop("disabled", true);
+    var formData = new FormData(this);
+    var url = this.action;
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: "json",
+      processData: false,
+      contentType: false
+    })
+      .done(function(data) {
+        var html = buildHTML(data);
+        var chat = $(".chat");
+        chat.append(html);
+        $("#new_message")[0].reset();
+        chat.animate({ scrollTop: chat[0].scrollHeight }, 100);
+      })
+      .fail(function() {
+        alert("メッセージ送信に失敗しました");
+      });
+  });
 
   setInterval(updateMessages, 5000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -43,4 +43,23 @@ $(document).on("turbolinks:load", function() {
         alert("メッセージ送信に失敗しました");
       });
   });
+
+  $(".chat").on("click", function() {
+    var last_message = $(".chat__message").last();
+    var latest_message_id = last_message.data("message-id");
+    console.log(latest_message_id);
+    var url = location.pathname.replace("/messages", "/api/messages");
+    $.ajax({
+      type: "GET",
+      url: url,
+      data: { latest_message_id: latest_message_id },
+      dataType: "json"
+    })
+      .done(function(data) {
+        console.log(data);
+      })
+      .fail(function() {
+        alert("データの取得に失敗しました");
+      });
+  });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,5 @@
-var $;
+var $, chatUpdateScheduler;
+
 $(document).on("turbolinks:load", function() {
   function isChatUrl(pathname) {
     var urlPatternChatView = /\/groups\/\d+\/messages/;
@@ -77,5 +78,11 @@ $(document).on("turbolinks:load", function() {
       });
   });
 
-  setInterval(updateMessages, 5000);
+  if (chatUpdateScheduler) {
+    clearInterval(chatUpdateScheduler);
+  }
+
+  if (isChatUrl(location.pathname)) {
+    chatUpdateScheduler = setInterval(updateMessages, 5000);
+  }
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -7,6 +7,7 @@ $(document).on("turbolinks:load", function() {
 
     var html = `
     <div class="chat__message">
+    <div class="chat__message" data-message-id="${message.message_id}">
       <div class="chat__message__info">
         <div class="chat__message__info__username">${message.user_name}</div>
         <div class="chat__message__info__date">${message.updated_at}</div>

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -29,7 +29,6 @@ $(document).on("turbolinks:load", function() {
   function updateMessages() {
     var last_message = $(".chat__message").last();
     var latest_message_id = last_message.data("message-id");
-    console.log(latest_message_id);
     var url = location.pathname.replace("/messages", "/api/messages");
     $.ajax({
       type: "GET",
@@ -38,7 +37,6 @@ $(document).on("turbolinks:load", function() {
       dataType: "json"
     })
       .done(function(data) {
-        console.log(data);
         var chat = $(".chat");
         if (data.length !== 0) {
           data.forEach(function(message) {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -43,7 +43,7 @@ $(document).on("turbolinks:load", function() {
       });
   });
 
-  $(".chat").on("click", function() {
+  function updateMessages() {
     var last_message = $(".chat__message").last();
     var latest_message_id = last_message.data("message-id");
     console.log(latest_message_id);
@@ -68,5 +68,7 @@ $(document).on("turbolinks:load", function() {
       .fail(function() {
         alert("データの取得に失敗しました");
       });
-  });
+  }
+
+  setInterval(updateMessages, 5000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -63,6 +63,7 @@ $(document).on("turbolinks:load", function() {
             var html = buildHTML(message);
             chat.append(html);
           });
+          chat.animate({ scrollTop: chat[0].scrollHeight }, 100);
         }
       })
       .fail(function() {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -57,6 +57,13 @@ $(document).on("turbolinks:load", function() {
     })
       .done(function(data) {
         console.log(data);
+        var chat = $(".chat");
+        if (data.length !== 0) {
+          data.forEach(function(message) {
+            var html = buildHTML(message);
+            chat.append(html);
+          });
+        }
       })
       .fail(function() {
         alert("データの取得に失敗しました");

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,2 @@
+class Api::MessagesController < ApplicationController
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,2 +1,4 @@
 class Api::MessagesController < ApplicationController
+  def index
+  end
 end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,7 +1,7 @@
 class Api::MessagesController < ApplicationController
   def index
     group = Group.find(params[:group_id])
-    latest_message_id = params[:id].to_i
+    latest_message_id = params[:latest_message_id].to_i
     @messages = group.messages.includes(:user).where("id > ?", latest_message_id)
   end
 end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,4 +1,7 @@
 class Api::MessagesController < ApplicationController
   def index
+    group = Group.find(params[:group_id])
+    latest_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", latest_message_id)
   end
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,4 +1,5 @@
 json.array! @messages do |message|
+  json.message_id message.id
   json.user_name message.user.name
   json.updated_at message.updated_at.strftime("%Y/%m/%d(%a) %H:%M")
   json.content message.content

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.user_name message.user.name
+  json.updated_at message.updated_at.strftime("%Y/%m/%d(%a) %H:%M")
+  json.content message.content
+  json.image_url message.image_url
+  json.image_alt message.image.identifier
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.chat__message
+.chat__message{ data: { "message-id": message.id} }
   .chat__message__info
     .chat__message__info__username=message.user.name
     .chat__message__info__date=message.updated_at.strftime("%Y/%m/%d(%a) %H:%M")

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,6 +1,6 @@
 .chat__message
   .chat__message__info
     .chat__message__info__username=message.user.name
-    .chat__message__info__date=message.updated_at.strftime("%Y/%m/%d %H:%M")
+    .chat__message__info__date=message.updated_at.strftime("%Y/%m/%d(%a) %H:%M")
   .chat__message__text=message.content
   = image_tag message.image.to_s

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,3 +1,4 @@
+json.message_id @new_message.id
 json.user_name @new_message.user.name
 json.updated_at @new_message.updated_at.strftime("%Y/%m/%d(%a) %H:%M")
 json.content @new_message.content

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   resources :groups, only: ["edit", "update", "new", "create"] do
     resources :messages, only: ["index", "create"]
     namespace :api do
-      resources :messages, only: ["index"]
+      resources :messages, only: ["index"], defaults: { format: "json" }
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "groups#index"
+  namespace :api do
+    resources :messages, only: ["index"]
+  end
   resources :users, only: ["index", "edit", "update"]
   resources :groups, only: ["edit", "update", "new", "create"] do
     resources :messages, only: ["index", "create"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,11 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "groups#index"
-  namespace :api do
-    resources :messages, only: ["index"]
-  end
   resources :users, only: ["index", "edit", "update"]
   resources :groups, only: ["edit", "update", "new", "create"] do
     resources :messages, only: ["index", "create"]
+    namespace :api do
+      resources :messages, only: ["index"]
+    end
   end
 end


### PR DESCRIPTION
# what
- chatspaceで送信されたメッセージを自動更新する機能を実装する。
- チャット欄で最新のメッセージのidを取得するためhamlを編集してdata属性にidを付与する。
- setInterval関数を使用し、一定時間ごとにチャット欄の最新のメッセージのidをajaxで送信する。
- ajaxでのリクエストを受け付けるコントローラーを実装する。
    - jsonのデータ送信のみを行うアクションを実装するので、コントローラーはapiという名前空間に入れる。
    - チャットグループidをコントローラーにわたすためgroupsコントローラーにルーティングをネストさせる。
- メッセージの送信を適切なjsonフォーマットで行うためjbuilderを使う。
- ajaxのdoneメソッドで受け取ったデータをチャット欄に埋め込む。
- 最新のメッセージまでチャット欄をスクロールするためjqueryのanimateメソッドを使う。
- ページのurlに応じてsetIntervalまたはclearInterval関数を使い、チャット画面以外での自動更新の関数が動作しないようにする。
# why
- 自動でチャットを更新できると、ユーザーが手動更新する手間を省けるためチャットの利便性が向上する。
- data属性を使って必要なデータのやりとりをすることで、htmlテンプレートの見通しが悪くなるのを避けられる。
# 実装内容の動作状況の動画
- [キャプチャ動画 - 68d10bbaece880b07dd3e5e8fe990ecb - Gyazo](https://gyazo.com/68d10bbaece880b07dd3e5e8fe990ecb)