### PR TITLE
デプロイするブランチをローカルの設定ファイルで変更する

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -43,6 +43,6 @@ require 'capistrano/rails/migrations'
 require 'capistrano3/unicorn'
 
 require 'config'
-Config.load_and_set_settings("config/settings.yml")
+Config.load_and_set_settings("config/settings.yml", "config/settings.local.yml")
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -62,4 +62,4 @@
 
 server Settings.capistrano.aws_elastic_ip, user: Settings.capistrano.aws_user_name, roles: %w{app db web}
 
-set :branch, Settings.capistrano.deploy_branch
+set :branch, (Settings.capistrano.deploy_branch || "master")

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,4 @@
 capistrano:
-  deploy_branch: "dev/ito/deploy"
   aws_elastic_ip: "18.177.242.103"
   aws_user_name: "ec2-user"
   version_lock: "3.11.2"


### PR DESCRIPTION
# what
gitで管理しないローカルのファイルにてデプロイブランチを切り替えるようにした。

# why
master以外のブランチをデプロイして動作確認する際に、git管理下のファイルを変更すると、コミットが必要になるから。