### PR TITLE
投稿画像のファイルサイズ、ファイルタイプを制限する

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -65,11 +65,15 @@ $(document).on("turbolinks:load", function() {
       contentType: false
     })
       .done(function(data) {
-        var html = buildHTML(data);
-        var chat = $(".chat");
-        chat.append(html);
-        $("#new_message")[0].reset();
-        chat.animate({ scrollTop: chat[0].scrollHeight }, 100);
+        if (data.status == "success") {
+          var html = buildHTML(data);
+          var chat = $(".chat");
+          chat.append(html);
+          $("#new_message")[0].reset();
+          chat.animate({ scrollTop: chat[0].scrollHeight }, 100);
+        } else {
+          alert(data.error_message);
+        }
       })
       .fail(function() {
         alert("メッセージ送信に失敗しました");

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -17,7 +17,14 @@ class MessagesController < ApplicationController
         end
       end
 
-      format.json
+      format.json do
+        if @new_message.errors.empty?
+          @status = "success"
+        else
+          @status = "failed"
+          @error_message = @new_message.errors.full_messages.join("\n")
+        end
+      end
     end
   end
 

--- a/app/uploaders/images_uploader.rb
+++ b/app/uploaders/images_uploader.rb
@@ -39,7 +39,7 @@ class ImagesUploader < CarrierWave::Uploader::Base
   #   process resize_to_fit: [50, 50]
   # end
   def size_range
-    1..1.kilobytes
+    1..500.kilobytes
   end
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:

--- a/app/uploaders/images_uploader.rb
+++ b/app/uploaders/images_uploader.rb
@@ -38,12 +38,14 @@ class ImagesUploader < CarrierWave::Uploader::Base
   # version :thumb do
   #   process resize_to_fit: [50, 50]
   # end
-
+  def size_range
+    1..1.kilobytes
+  end
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_whitelist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_whitelist
+    %w(jpg jpeg gif png)
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,6 +1,12 @@
-json.message_id @new_message.id
-json.user_name @new_message.user.name
-json.updated_at @new_message.updated_at.strftime("%Y/%m/%d(%a) %H:%M")
-json.content @new_message.content
-json.image_url @new_message.image_url
-json.image_alt @new_message.image.identifier
+if @status == "success"
+  json.status @status
+  json.message_id @new_message.id
+  json.user_name @new_message.user.name
+  json.updated_at @new_message.updated_at.strftime("%Y/%m/%d(%a) %H:%M")
+  json.content @new_message.content
+  json.image_url @new_message.image_url
+  json.image_alt @new_message.image.identifier
+else
+  json.status @status
+  json.error_message @error_message
+end

--- a/config/locales/carrierwave.ja.yml
+++ b/config/locales/carrierwave.ja.yml
@@ -1,0 +1,14 @@
+ja:
+  errors:
+    messages:
+      carrierwave_processing_error: 処理できませんでした
+      carrierwave_integrity_error: は許可されていないファイルタイプです
+      carrierwave_download_error: はダウンロードできません
+      extension_whitelist_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: %{allowed_types}"
+      extension_blacklist_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできないファイルタイプ: %{prohibited_types}"
+      content_type_whitelist_error: "%{content_type}ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: %{allowed_types}"
+      content_type_blacklist_error: "%{content_type}ファイルのアップロードは許可されていません"
+      rmagick_processing_error: "rmagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
+      mini_magick_processing_error: "MiniMagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
+      min_size_error: "を%{min_size}以上のサイズにしてください"
+      max_size_error: "を%{max_size}以下のサイズにしてください"

--- a/config/locales/models.ja.yml
+++ b/config/locales/models.ja.yml
@@ -1,0 +1,6 @@
+ja:
+  activerecord:
+    attributes:
+        message:
+            image: 画像
+            content: メッセージ


### PR DESCRIPTION
# what
- jpg, png, gifの画像の以外のファイル投稿できないようにした
- 投稿画像のファイルサイズを500KB以下に制限した
- ファイルサイズやファイルタイプが不正な場合のエラーを日本語で表示するようにした

# why
- 大容量のファイルがアップロードされてAWSの課金額が増加するのを避けるため
- Userモデル以外でのエラーは日本語化できておらず画像投稿のエラーが英語表示になっていたため
